### PR TITLE
Add unit tests for consistency checking when used to generate two worlds in a row.

### DIFF
--- a/src/iog_randomizer/randomizer/classes.py
+++ b/src/iog_randomizer/randomizer/classes.py
@@ -29,11 +29,16 @@ MAX_CYCLES = 200
 
 
 class World:
+
     def __eq__(self, other):
+        """
+        This works only as long as an extra attribute isn't written to one of the instantiated objects,
+        for example through a subclass, in which case this function would return False.
+        Ideally, only the attributes relevant to the class should be tested here.
+        """
         if isinstance(other, self.__class__):
             return self.__dict__ == other.__dict__
-        else:
-            return False
+        return False
 
     # Severity: 0 = error/breakpoint, 1 = warning, 2 = info, 3 = verbose.
     def log(self, message, severity=0):

--- a/src/iog_randomizer/randomizer/classes.py
+++ b/src/iog_randomizer/randomizer/classes.py
@@ -29,6 +29,12 @@ MAX_CYCLES = 200
 
 
 class World:
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
+
     # Severity: 0 = error/breakpoint, 1 = warning, 2 = info, 3 = verbose.
     def log(self, message, severity=0):
         prefixes = ["Error: ", "Warning: ", "", ""]

--- a/src/iog_randomizer/randomizer/iogr_rom.py
+++ b/src/iog_randomizer/randomizer/iogr_rom.py
@@ -614,11 +614,8 @@ class Randomizer:
             elif self.seed_adj > 0:
                 if settings.printlevel.value > -1:
                     print("Trying again... attempt", self.seed_adj + 1)
-
-            print(f"World({json.dumps(settings.__dict__, indent=1)}, {statues_required}, {statues}, {statue_req}, {kara_location}, {gem}, {[inca_x + 1, inca_y + 1]}, {hieroglyph_order}, {boss_order})")
             self.w = World(settings, statues_required, statues, statue_req, kara_location, gem,
                            [inca_x + 1, inca_y + 1], hieroglyph_order, boss_order)
-            print(f"self.w.randomize({self.seed_adj}, {settings.printlevel.value}, {settings.break_on_error}, {settings.break_on_init})")
             done = self.w.randomize(self.seed_adj, settings.printlevel.value, settings.break_on_error,
                                     settings.break_on_init)
             if profile_base_filepath != "":

--- a/src/iog_randomizer/randomizer/iogr_rom.py
+++ b/src/iog_randomizer/randomizer/iogr_rom.py
@@ -614,8 +614,11 @@ class Randomizer:
             elif self.seed_adj > 0:
                 if settings.printlevel.value > -1:
                     print("Trying again... attempt", self.seed_adj + 1)
+
+            print(f"World({json.dumps(settings.__dict__, indent=1)}, {statues_required}, {statues}, {statue_req}, {kara_location}, {gem}, {[inca_x + 1, inca_y + 1]}, {hieroglyph_order}, {boss_order})")
             self.w = World(settings, statues_required, statues, statue_req, kara_location, gem,
                            [inca_x + 1, inca_y + 1], hieroglyph_order, boss_order)
+            print(f"self.w.randomize({self.seed_adj}, {settings.printlevel.value}, {settings.break_on_error}, {settings.break_on_init})")
             done = self.w.randomize(self.seed_adj, settings.printlevel.value, settings.break_on_error,
                                     settings.break_on_init)
             if profile_base_filepath != "":

--- a/src/iog_randomizer/randomizer/models/enums.py
+++ b/src/iog_randomizer/randomizer/models/enums.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import IntEnum, StrEnum
 
 
-class DarkRooms(Enum):
+class DarkRooms(IntEnum):
     ALLCURSED = -4
     MANYCURSED = -3
     SOMECURSED = -2
@@ -13,21 +13,21 @@ class DarkRooms(Enum):
     ALL = 4
 
 
-class Difficulty(Enum):
+class Difficulty(IntEnum):
     EASY = 0
     NORMAL = 1
     HARD = 2
     EXTREME = 3
 
 
-class DungeonShuffle(Enum):
+class DungeonShuffle(IntEnum):
     NONE = 0
     BASIC = 1
     CHAOS = 2
     CLUSTERED = 3
 
 
-class Enemizer(Enum):
+class Enemizer(IntEnum):
     NONE = 0
     LIMITED = 1
     BALANCED = 2
@@ -35,45 +35,45 @@ class Enemizer(Enum):
     INSANE = 4
 
 
-class EntranceShuffle(Enum):
+class EntranceShuffle(IntEnum):
     NONE = 0
     COUPLED = 1
     UNCOUPLED = 2
 
 
-class FluteOpt(Enum):
+class FluteOpt(IntEnum):
     START = 0
     SHUFFLE = 1
     FLUTELESS = 2
 
 
-class Goal(Enum):
+class Goal(IntEnum):
     DARK_GAIA = 0
     RED_JEWEL_HUNT = 1
     APO_GAIA = 2
     RANDOM_GAIA = 3
 
 
-class Level(Enum):
+class Level(IntEnum):
     BEGINNER = 0
     INTERMEDIATE = 1
     ADVANCED = 2
     EXPERT = 3
 
 
-class Logic(Enum):
+class Logic(IntEnum):
     COMPLETABLE = 0
     BEATABLE = 1
     CHAOS = 2
 
 
-class OrbRando(Enum):
+class OrbRando(IntEnum):
     NONE = 0
     BASIC = 1
     ORBSANITY = 2
 
 
-class Sprite(Enum):
+class Sprite(StrEnum):
     WILL = "will"
     BAGU = "bagu"
     INVISIBLE = "invisible"
@@ -82,20 +82,20 @@ class Sprite(Enum):
     SYE = "sye"
 
 
-class StartLocation(Enum):
+class StartLocation(IntEnum):
     SOUTH_CAPE = 0
     SAFE = 1
     UNSAFE = 2
     FORCED_UNSAFE = 3
 
 
-class StatueReq(Enum):
+class StatueReq(IntEnum):
     GAME_CHOICE = 0
     PLAYER_CHOICE = 1
     RANDOM_CHOICE = 2
 
 
-class PrintLevel(Enum):
+class PrintLevel(IntEnum):
     SILENT = -1
     ERROR = 0
     WARN = 1

--- a/tests/iog_randomizer/randomizer/test_world_randomize.py
+++ b/tests/iog_randomizer/randomizer/test_world_randomize.py
@@ -50,11 +50,6 @@ def get_world(settings) -> World:
         boss_order=[1, 2, 3, 4, 5, 6, 7]
     )
 
-'''
-During a refactor, there was a bug where module imported data was mutatable.
-This test will catch a specific reproducible scenario ensuring a second 
-different world can be generated with current state.
-'''
 def test_can_randomize_with_different_settings_twice():
     world = get_world(get_default_randomizer_data())
     done = world.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
@@ -63,20 +58,13 @@ def test_can_randomize_with_different_settings_twice():
     changed_settings = get_default_randomizer_data()
     changed_settings.ohko = True
     world_changed = get_world(changed_settings)
-    done_changed = world_changed.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
-    assert done_changed == True
+    assert world_changed.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
 
-'''
-During a refactor, there was a bug where module imported data was mutatable.
-This test will catch a specific reproducible scenario ensuring two worlds with the same settings will match.
-'''
 def test_can_randomize_with_same_settings_twice():
     world = get_world(get_default_randomizer_data())
-    done = world.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
-    assert done == True
+    assert world.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
 
     second_world = get_world(get_default_randomizer_data())
-    second_world_done = second_world.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
-    assert second_world_done == True
+    assert second_world.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
 
     assert world == second_world

--- a/tests/iog_randomizer/randomizer/test_world_randomize.py
+++ b/tests/iog_randomizer/randomizer/test_world_randomize.py
@@ -1,0 +1,82 @@
+import json
+
+from iog_randomizer.randomizer.classes import World
+from iog_randomizer.randomizer.models.enums import *
+from iog_randomizer.randomizer.models.randomizer_data import RandomizerData
+
+
+def get_default_randomizer_data() -> RandomizerData:
+    return RandomizerData(seed=13371337,
+        difficulty=Difficulty.NORMAL,
+        goal=Goal.DARK_GAIA,
+        logic=Logic.COMPLETABLE,
+        statues="4",
+        statue_req=StatueReq.GAME_CHOICE,
+        start_location=StartLocation.SOUTH_CAPE,
+        enemizer=Enemizer.NONE,
+        firebird=False,
+        ohko=False,
+        red_jewel_madness=False,
+        allow_glitches=False,
+        boss_shuffle=False,
+        open_mode=False,
+        z3=False,
+        coupled_exits=True,
+        town_shuffle=False,
+        dungeon_shuffle=False,
+        overworld_shuffle=False,
+        race_mode=False,
+        flute=FluteOpt.START,
+        sprite=Sprite.WILL,
+        orb_rando=False,
+        darkrooms=DarkRooms.NONE,
+        printlevel=PrintLevel.SILENT,
+        break_on_error=False,
+        break_on_init=False,
+        ingame_debug=False,
+        infinite_inventory=False,
+        ds_warp=False,
+    )
+
+def get_world(settings) -> World:
+    return World(settings=settings,
+        statues_required=4,
+        statues=[2, 3, 1, 5],
+        statue_req=0,
+        kara=1,
+        gem=[1, 5, 9, 11, 18, 24, 38],
+        incatile=[10, 5],
+        hieroglyphs=[4, 2, 5, 3, 1, 6],
+        boss_order=[1, 2, 3, 4, 5, 6, 7]
+    )
+
+'''
+During a refactor, there was a bug where module imported data was mutatable.
+This test will catch a specific reproducible scenario ensuring a second 
+different world can be generated with current state.
+'''
+def test_can_randomize_with_different_settings_twice():
+    world = get_world(get_default_randomizer_data())
+    done = world.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
+    assert done == True
+
+    changed_settings = get_default_randomizer_data()
+    changed_settings.ohko = True
+    world_changed = get_world(changed_settings)
+    done_changed = world_changed.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
+    assert done_changed == True
+
+'''
+During a refactor, there was a bug where module imported data was mutatable.
+This test will catch a specific reproducible scenario ensuring two worlds with the same settings will match.
+'''
+def test_can_randomize_with_same_settings_twice():
+    world = get_world(get_default_randomizer_data())
+    done = world.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
+    assert done == True
+
+    second_world = get_world(get_default_randomizer_data())
+    second_world_done = second_world.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
+    assert second_world_done == True
+
+    assert world == second_world

--- a/tests/iog_randomizer/randomizer/test_world_randomize.py
+++ b/tests/iog_randomizer/randomizer/test_world_randomize.py
@@ -52,8 +52,7 @@ def get_world(settings) -> World:
 
 def test_can_randomize_with_different_settings_twice():
     world = get_world(get_default_randomizer_data())
-    done = world.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
-    assert done == True
+    assert world.randomize(seed_adj=0, printlevel=PrintLevel.SILENT, break_on_error=True, break_on_init=False)
 
     changed_settings = get_default_randomizer_data()
     changed_settings.ohko = True

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,7 +1,0 @@
-# TODO: remove this when real tests appear, it's just for testing testing
-def func(x):
-    return x + 1
-
-
-def test_answer():
-    assert func(4) == 5


### PR DESCRIPTION
I needed to add `__eq__` to the `World` class in order to test for internal values of the object instead of the object reference itself.

I also migrated the enums from `Enum` to `StrEnum` and `IntEnum` because they serialized to string better when calling `json.dumps()`. I kept these `print` calls in there because they might be useful for inspecting data later on when generating. I can comment them out if it is desired.